### PR TITLE
fix(customers): make `nbCustomers` prop optional in `DeleteModal`

### DIFF
--- a/app/components/customers/DeleteModal.vue
+++ b/app/components/customers/DeleteModal.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 defineProps<{
-  nbCustomers: number
+  nbCustomers?: number
 }>()
 
 const open = ref(false)


### PR DESCRIPTION
fixes unexpected prop type when loading customers.