### PR TITLE
fix(home): apply `overflow-visible` on chart wrapper

### DIFF
--- a/app/components/home/HomeChart.client.vue
+++ b/app/components/home/HomeChart.client.vue
@@ -59,7 +59,7 @@ const template = (d: DataRecord) => `${formatDate(d.date)}: ${formatNumber(d.amo
 </script>
 
 <template>
-  <UCard ref="cardRef" :ui="{ body: '!px-0 !pt-0 !pb-3' }">
+  <UCard ref="cardRef" :ui="{ root: 'overflow-visible', body: '!px-0 !pt-0 !pb-3' }">
     <template #header>
       <div>
         <p class="text-xs text-muted uppercase mb-1.5">


### PR DESCRIPTION
[PR#4368](https://github.com/nuxt/ui/pull/4368) added `overflow-hidden` to all `UCard` components, which causes home chart to be clipped and invisible. This change overrides that with `overflow-visible`.