### PR TITLE
fix(customers): hide table separator

### DIFF
--- a/app/pages/customers.vue
+++ b/app/pages/customers.vue
@@ -297,7 +297,8 @@ const pagination = ref({
           thead: '[&>tr]:bg-elevated/50 [&>tr]:after:content-none',
           tbody: '[&>tr]:last:[&>td]:border-b-0',
           th: 'py-2 first:rounded-l-lg last:rounded-r-lg border-y border-default first:border-l last:border-r',
-          td: 'border-b border-default'
+          td: 'border-b border-default',
+          separator: 'h-0',
         }"
       />
 


### PR DESCRIPTION
<img width="1652" height="322" alt="image" src="https://github.com/user-attachments/assets/4dab9ddc-9580-4dfa-87e5-ce4130951fb9" />