### PR TITLE
fix(inbox): remove a typo in list

### DIFF
--- a/app/components/inbox/InboxList.vue
+++ b/app/components/inbox/InboxList.vue
@@ -66,7 +66,7 @@ defineShortcuts({
             <UChip v-if="mail.unread" />
           </div>
 
-          <span>{{ isToday(new Date(mail.date)) ? format(new Date(mail.date), "HH:mm") : format(new Date(mail.date), "dd MMM") }}</span>
+          <span>{{ isToday(new Date(mail.date)) ? format(new Date(mail.date), 'HH:mm') : format(new Date(mail.date), 'dd MMM') }}</span>
         </div>
         <p class="truncate" :class="[mail.unread && 'font-semibold']">
           {{ mail.subject }}


### PR DESCRIPTION
Fix a class name typo: 'text-toned)' on line 55